### PR TITLE
Update 0036-PaperSpigot-protocol-warning.patch

### DIFF
--- a/Spigot-Server-Patches/0036-PaperSpigot-protocol-warning.patch
+++ b/Spigot-Server-Patches/0036-PaperSpigot-protocol-warning.patch
@@ -13,11 +13,11 @@ index 83411db..f7676fd 100644
                  }
              }
 -            System.err.println("This Spigot build supports Minecraft clients both of versions 1.7.x and of 1.8.x.\n"
-+            System.err.println( "This PaperSpigot build only supports Minecraft 1.7.x and 1.8.x clients!\n"
++            System.err.println( "This PaperSpigot build only supports Minecraft 1.7.x, 1.8.x and 1.9.x clients!\n"
                      + "*** It is imperative that backups be taken before running this build on your server! ***\n"
 -                    + "Please report any such issues to http://www.spigotmc.org/, stating your client, server, and if applicable BungeeCord versions.\n"
 -                    + "*** Any bug reports not running the very latest versions of these softwares will be ignored ***\n\n");
-+                    + "Please report issues directly to Paper, and always ensure you're up-to-date!\n"
++                    + "Please report issues directly to lukas81298 (https://github.com/lukas81298/ProtocolHack-1.9/), and always ensure you're up-to-date!\n"
 +                    + "*** Any bug reports not running the very latest version of the software will be ignored ***\n\n" );
              // Spigot End
              try {


### PR DESCRIPTION
Well, we are supporting 1.9.x, right?

I also changed the "Please report issues directly to Paper" to "Please report issues directly to lukas81298 (https://github.com/lukas81298/ProtocolHack-1.9/)"
